### PR TITLE
Use an interface for Logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [0.4.0](https://github.com/botopolis/bot/compare/v0.3.0...v0.4.0) - 2018-06-24
+
+### Added
+
+- Mock that satisfies `bot.Logger` interface
+
+### Changed
+
+- `Robot.Logger` is now an interface.
+
+### Removed
+
+- `Robot.Debug()` has been removed. As you now have full control over the logger, you can set your logger's log level without involving `bot.Robot`.

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -20,12 +20,6 @@
   version = "v1.6.1"
 
 [[projects]]
-  name = "github.com/op/go-logging"
-  packages = ["."]
-  revision = "b2cb9fa56473e98db8caba80237377e83fe44db5"
-  version = "v1"
-
-[[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
@@ -40,6 +34,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "60e3c51dec4bcf9ea9a6784b435bfee94a78e99826aa57416d25b1c599872594"
+  inputs-digest = "5b0135006424a2e27ff802b5a49094ef75e2324bb377a51081cec6ea7f52f834"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,3 @@
 [[constraint]]
-  name = "github.com/op/go-logging"
-
-[[constraint]]
   name = "github.com/gorilla/mux"
   version = "1.6.1"

--- a/README.md
+++ b/README.md
@@ -175,13 +175,13 @@ You can set the server port with an environment variable `PORT`:
 PORT=4567 ./botopolis
 ```
 
-### Debug logging
+### Custom logging
 
-You can set debug logging via method call:
+You can set up your own logger as long as it satisfies the
+[Logger](https://godoc.org/github.com/botopolis/bot#Logger) interface.
 
 ```go
-r := bot.New(mock.NewChat())
-r.Debug(true)
-r.Run()
-// Runs with debug logging
+robot := bot.New(mychat.Plugin{})
+robot.Logger = MyCustomLogger{}
+robot.Run()
 ```

--- a/example_test.go
+++ b/example_test.go
@@ -21,10 +21,8 @@ func Example() {
 	go func() { close(chat.MessageChan) }()
 
 	// Install adapter and plugins
-	robot := bot.New(
-		chat,
-		&ExamplePlugin{},
-	)
+	robot := bot.New(chat, &ExamplePlugin{})
+	robot.Logger = mock.NewLogger()
 
 	// Respond to any message
 	robot.Hear(bot.Regexp("welcome (\\w*)"), func(r bot.Responder) error {

--- a/logger.go
+++ b/logger.go
@@ -1,22 +1,43 @@
 package bot
 
 import (
+	"log"
 	"os"
-
-	"github.com/op/go-logging"
 )
 
-var stdout = logging.AddModuleLevel(
-	logging.NewBackendFormatter(
-		logging.NewLogBackend(os.Stdout, "", 0),
-		logging.MustStringFormatter(`%{time:2006-01-02T15:04:05} bot ▶ %{color}%{level:.4s}%{color:reset} %{message}`),
-	),
-)
+// Logger is the interface Robot exposes
+type Logger interface {
+	Debug(values ...interface{})
+	Debugf(format string, values ...interface{})
 
-func newLogger() *logging.Logger {
-	log := logging.MustGetLogger("bot")
-	stdout.SetLevel(logging.INFO, "")
-	log.SetBackend(stdout)
+	Info(values ...interface{})
+	Infof(format string, values ...interface{})
 
-	return log
+	Warn(values ...interface{})
+	Warnf(format string, values ...interface{})
+
+	Error(values ...interface{})
+	Errorf(format string, values ...interface{})
+
+	Fatal(values ...interface{})
+	Fatalf(format string, values ...interface{})
+
+	Panic(values ...interface{})
+	Panicf(format string, values ...interface{})
 }
+
+// defaultLogger is a very basic logger that the bot loads by default
+var defaultLogger = basicLogger{log.New(os.Stdout, "", 0)}
+
+type basicLogger struct{ *log.Logger }
+
+func (l basicLogger) Debug(v ...interface{})            {}
+func (l basicLogger) Debugf(f string, v ...interface{}) {}
+func (l basicLogger) Info(v ...interface{})             { l.Logger.Println(v...) }
+func (l basicLogger) Infof(f string, v ...interface{})  { l.Logger.Printf(f, v...) }
+func (l basicLogger) Warn(v ...interface{})             { l.Logger.Println(v...) }
+func (l basicLogger) Warnf(f string, v ...interface{})  { l.Logger.Printf(f, v...) }
+func (l basicLogger) Error(v ...interface{})            { l.Logger.Println(v...) }
+func (l basicLogger) Errorf(f string, v ...interface{}) { l.Logger.Printf(f, v...) }
+func (l basicLogger) Panic(v ...interface{})            { l.Logger.Panicln(v...) }
+func (l basicLogger) Panicf(f string, v ...interface{}) { l.Logger.Panicf(f, v...) }

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,43 @@
+package bot_test
+
+import (
+	"fmt"
+
+	"github.com/botopolis/bot"
+	"github.com/botopolis/bot/mock"
+)
+
+type logStuff struct{}
+
+func (logStuff) Load(r *bot.Robot) {
+	r.Logger.Error("One")
+	r.Logger.Panic("Two")
+	r.Logger.Fatal("Three")
+}
+
+func ExampleLogger() {
+	// Ignore this - just example setup
+	chat := mock.NewChat()
+	chat.MessageChan = make(chan bot.Message)
+	go func() { close(chat.MessageChan) }()
+
+	logger := mock.NewLogger()
+	logger.WriteFunc = func(level mock.Level, v ...interface{}) {
+		switch level {
+		case mock.ErrorLevel:
+			fmt.Println("Error log")
+		case mock.PanicLevel:
+			fmt.Println("Panic log")
+		case mock.FatalLevel:
+			fmt.Println("Fatal log")
+
+		}
+	}
+	b := bot.New(chat, logStuff{})
+	b.Logger = logger
+	b.Run()
+	// Output:
+	// Error log
+	// Panic log
+	// Fatal log
+}

--- a/mock/logger.go
+++ b/mock/logger.go
@@ -1,0 +1,71 @@
+package mock
+
+// Level is the log level
+type Level int
+
+const (
+	// DebugLevel is the debug level
+	DebugLevel Level = iota
+	// InfoLevel is the info level
+	InfoLevel
+	// WarnLevel is the warn level
+	WarnLevel
+	// ErrorLevel is the error level
+	ErrorLevel
+	// FatalLevel is the fatal level
+	FatalLevel
+	// PanicLevel is the panic level
+	PanicLevel
+)
+
+// NewLogger creates a mock logger
+func NewLogger() *Logger {
+	return &Logger{
+		WriteFunc:  func(Level, ...interface{}) {},
+		WritefFunc: func(Level, string, ...interface{}) {},
+	}
+}
+
+// Logger is a mock logger
+type Logger struct {
+	// WriteFunc intercepts non-formatted logs
+	WriteFunc func(Level, ...interface{})
+	// WritefFunc intercepts formatted logs
+	WritefFunc func(Level, string, ...interface{})
+}
+
+// Debug logs at DebugLevel
+func (l *Logger) Debug(v ...interface{}) { l.WriteFunc(DebugLevel, v...) }
+
+// Debugf logs at DebugLevel with formatting
+func (l *Logger) Debugf(fmt string, v ...interface{}) { l.WritefFunc(DebugLevel, fmt, v...) }
+
+// Info logs at InfoLevel
+func (l *Logger) Info(v ...interface{}) { l.WriteFunc(InfoLevel, v...) }
+
+// Infof logs at InfoLevel with formatting
+func (l *Logger) Infof(fmt string, v ...interface{}) { l.WritefFunc(InfoLevel, fmt, v...) }
+
+// Warn logs at WarnLevel
+func (l *Logger) Warn(v ...interface{}) { l.WriteFunc(WarnLevel, v...) }
+
+// Warnf logs at WarnLevel with formatting
+func (l *Logger) Warnf(fmt string, v ...interface{}) { l.WritefFunc(WarnLevel, fmt, v...) }
+
+// Error logs at ErrorLevel
+func (l *Logger) Error(v ...interface{}) { l.WriteFunc(ErrorLevel, v...) }
+
+// Errorf logs at ErrorLevel with formatting
+func (l *Logger) Errorf(fmt string, v ...interface{}) { l.WritefFunc(ErrorLevel, fmt, v...) }
+
+// Fatal logs at FatalLevel
+func (l *Logger) Fatal(v ...interface{}) { l.WriteFunc(FatalLevel, v...) }
+
+// Fatalf logs at FatalLevel with formatting
+func (l *Logger) Fatalf(fmt string, v ...interface{}) { l.WritefFunc(FatalLevel, fmt, v...) }
+
+// Panic logs at PanicLevel
+func (l *Logger) Panic(v ...interface{}) { l.WriteFunc(PanicLevel, v...) }
+
+// Panicf logs at PanicLevel with formatting
+func (l *Logger) Panicf(fmt string, v ...interface{}) { l.WritefFunc(PanicLevel, fmt, v...) }

--- a/robot.go
+++ b/robot.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/op/go-logging"
 )
 
 const timeout = 15
@@ -21,7 +20,7 @@ type Robot struct {
 	// HTTP Router
 	Router *mux.Router
 	// Logger with levels
-	Logger *logging.Logger
+	Logger Logger
 
 	plugins   *pluginRegistry
 	internals *pluginRegistry
@@ -35,7 +34,7 @@ func New(c Chat, plugins ...Plugin) *Robot {
 		Chat:   c,
 		Brain:  NewBrain(),
 		Router: mux.NewRouter(),
-		Logger: newLogger(),
+		Logger: defaultLogger,
 
 		plugins:   newPluginRegistry(),
 		internals: newPluginRegistry(),
@@ -85,7 +84,7 @@ func (r *Robot) gracefulShutdown() {
 		}()
 		select {
 		case <-time.After(timeout * time.Second):
-			r.Logger.Info("Force quitting after %ds timeout", timeout)
+			r.Logger.Infof("Force quitting after %ds timeout", timeout)
 			os.Exit(1)
 		case <-done:
 			os.Exit(0)
@@ -129,12 +128,3 @@ func (r *Robot) Topic(h hook) { go r.onMessage(Topic, nil, h) }
 
 // Username provides the robot's username
 func (r *Robot) Username() string { return r.Chat.Username() }
-
-// Debug sets the log-level to debug
-func (r *Robot) Debug(debug bool) {
-	if debug {
-		stdout.SetLevel(logging.DEBUG, "")
-	} else {
-		stdout.SetLevel(logging.INFO, "")
-	}
-}


### PR DESCRIPTION
Allow for custom loggers to be used by making the logger an interface.

Supported out of the box:
github.com/sirupsen/logrus

Also adds a mock logger for easy assertions and to be able to silence
the logger in tests.