### PR TITLE
Implement ability to expose help information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # botopolis
 
-[![GoDoc](https://godoc.org/github.com/botopolis/bot?status.svg)](https://godoc.org/github.com/botopolis/bot) [![Build Status](https://travis-ci.org/botopolis/bot.svg?branch=master)](https://travis-ci.org/botopolis/bot) [![Test Coverage](https://api.codeclimate.com/v1/badges/b7acc61121363e7405a3/test_coverage)](https://codeclimate.com/github/botopolis/bot/test_coverage)
+[![GoDoc](https://godoc.org/github.com/botopolis/bot?status.svg)](https://godoc.org/github.com/botopolis/bot) [![Build Status](https://circleci.com/gh/botopolis/bot.svg?style=svg)](https://circleci.com/gh/botopolis/bot) [![Test Coverage](https://api.codeclimate.com/v1/badges/b7acc61121363e7405a3/test_coverage)](https://codeclimate.com/github/botopolis/bot/test_coverage)
 
 A hubot clone in Go! botopolis is extendable with plugins and works with different
 chat services.

--- a/help/README.md
+++ b/help/README.md
@@ -1,0 +1,19 @@
+# botopolis/help
+
+[![GoDoc](https://godoc.org/github.com/botopolis/bot/help?status.svg)](https://godoc.org/github.com/botopolis/bot/help) [![Build Status](https://circleci.com/gh/botopolis/bot.svg?style=svg)](https://circleci.com/gh/botopolis/bot) [![Test Coverage](https://api.codeclimate.com/v1/badges/b7acc61121363e7405a3/test_coverage)](https://codeclimate.com/github/botopolis/bot/test_coverage)
+
+Output about your botopolis commands.
+
+## Usage
+
+See [example_test.go](./example_test.go) for usage details.
+
+### Example output
+
+```
+user: @bot help
+bot:
+  help - Displays all the help commands that this bot knows about.
+  help <query> - Displays all help commands that match <query>.
+```
+

--- a/help/example_test.go
+++ b/help/example_test.go
@@ -1,0 +1,76 @@
+package help_test
+
+import (
+	"fmt"
+
+	"github.com/botopolis/bot"
+	"github.com/botopolis/bot/help"
+	"github.com/botopolis/bot/mock"
+)
+
+type HelperPlugin struct{ *mock.Plugin }
+
+func (HelperPlugin) Help() []help.Text {
+	return []help.Text{
+		{Respond: true, Command: "foo", Description: "bar"},
+		{Respond: false, Command: "baz", Description: "bar"},
+	}
+}
+
+type mockChat struct {
+	blocking chan struct{}
+	*mock.Chat
+}
+
+func newMockChat() *mockChat {
+	m := &mockChat{Chat: mock.NewChat(), blocking: make(chan struct{})}
+	m.Name = "bot"
+	m.MessageChan = make(chan bot.Message, 1)
+	m.SendFunc = func(msg bot.Message) error {
+		fmt.Println(msg.Text)
+		close(m.blocking)
+		return nil
+	}
+	return m
+}
+
+func (m *mockChat) SendMessage(text string) {
+	m.MessageChan <- bot.Message{Text: text}
+	close(m.MessageChan)
+}
+
+func (m *mockChat) Wait() { <-m.blocking }
+
+func Example() {
+	chat := newMockChat()
+	go chat.SendMessage("@bot help")
+
+	bot.New(
+		chat,
+		help.New(),
+		&HelperPlugin{mock.NewPlugin()},
+	).Run()
+
+	chat.Wait()
+	// Output:
+	// bot help - Displays all the help commands that this bot knows about.
+	// bot help <query> - Displays all help commands that match <query>.
+	// bot foo - bar
+	// baz - bar
+}
+
+func Example_withQuery() {
+	chat := newMockChat()
+	go chat.SendMessage("@bot help bar")
+
+	bot.New(
+		chat,
+		help.New(),
+		&HelperPlugin{mock.NewPlugin()},
+	).Run()
+
+	chat.Wait()
+	// Output:
+	// bot foo - bar
+	// baz - bar
+}

--- a/help/help.go
+++ b/help/help.go
@@ -1,0 +1,109 @@
+package help
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/botopolis/bot"
+)
+
+// Plugin is the help Plugin for botopolis/bot. It implements
+// bot.Plugin and help.Helper.
+type Plugin struct {
+	bot   *bot.Robot
+	once  sync.Once
+	cache []string
+}
+
+// New creates a new instance of the help plugin.
+func New() bot.Plugin { return &Plugin{} }
+
+// Provider is the interface a Plugin is expected to implement
+// in order to provide help text.
+type Provider interface {
+	Help() []Text
+}
+
+// Text is a representation of what is returned to the user.
+// Example:
+// Text{Respond: true, Command: "foo", Description: "bar"}
+// turns into
+// "<robot.Username> foo - bar"
+type Text struct {
+	// Respond is true if the command needs to be sent at a bot.
+	// Example: @bot <command>
+	Respond bool
+	// The command for which we are writing help text.
+	// Example: create link <name> <link>
+	Command string
+	// The description of the command.
+	// Example: Creates a link with the <name> short URL to the <link>.
+	Description string
+}
+
+func (p Text) format(r *bot.Robot) string {
+	var at string
+	if p.Respond {
+		at = fmt.Sprintf("%s ", r.Username())
+	}
+
+	return fmt.Sprintf("%s%s - %s", at, p.Command, p.Description)
+}
+
+// Load starts the help.Plugin, starts listening for help commands.
+func (p *Plugin) Load(r *bot.Robot) {
+	p.bot = r
+
+	r.Respond(bot.Regexp(`help\s*(.*)`), func(r bot.Responder) error {
+		p.loadCache()
+
+		return r.Send(bot.Message{
+			Text: p.buildResponse(r.Match[1]),
+		})
+	})
+}
+
+func (p *Plugin) loadCache() {
+	p.once.Do(func() {
+		for _, plugin := range p.bot.ListPlugins() {
+			if helper, ok := plugin.(Provider); ok {
+				for _, helpText := range helper.Help() {
+					p.cache = append(p.cache, helpText.format(p.bot))
+				}
+			}
+		}
+	})
+}
+
+func (p *Plugin) buildResponse(query string) string {
+	if query == "" {
+		return strings.Join(p.cache, "\n")
+	}
+
+	var partialMatch []string
+	for _, text := range p.cache {
+		if strings.Contains(strings.ToLower(text), strings.ToLower(query)) {
+			partialMatch = append(partialMatch, text)
+		}
+	}
+	return strings.Join(partialMatch, "\n")
+}
+
+// Help provides helper text and implements the help.Helper interface.
+func (p *Plugin) Help() []Text {
+	return []Text{
+		{
+			Respond:     true,
+			Command:     "help",
+			Description: "Displays all the help commands that this bot knows about.",
+		},
+		{
+			Respond:     true,
+			Command:     "help <query>",
+			Description: "Displays all help commands that match <query>.",
+		},
+	}
+}
+
+var _ Provider = &Plugin{}

--- a/plugin.go
+++ b/plugin.go
@@ -54,6 +54,14 @@ func (reg *pluginRegistry) Get(p Plugin) bool {
 	return false
 }
 
+func (reg *pluginRegistry) List() []Plugin {
+	plugins := make([]Plugin, 0, len(reg.registry))
+	for _, i := range reg.loadOrder {
+		plugins = append(plugins, reg.registry[i])
+	}
+	return plugins
+}
+
 func (reg *pluginRegistry) Load(r *Robot) {
 	for _, t := range reg.loadOrder {
 		if p, ok := reg.registry[t]; ok {

--- a/plugin_internal_test.go
+++ b/plugin_internal_test.go
@@ -67,3 +67,13 @@ func TestPluginLoad(t *testing.T) {
 		"Should unload the plugins in reverse order",
 	)
 }
+
+func TestPluginList(t *testing.T) {
+	type TestPluginTwo struct{ TestPlugin }
+	reg := newPluginRegistry()
+	p1 := TestPlugin{}
+	p2 := TestPluginTwo{}
+
+	reg.Add(&p1, &p2)
+	assert.Equal(t, []Plugin{&p1, &p2}, reg.List())
+}

--- a/robot.go
+++ b/robot.go
@@ -58,6 +58,11 @@ func (r *Robot) Plugin(p Plugin) bool {
 	return ok
 }
 
+// ListPlugins returns a slice of all loaded plugins.
+func (r *Robot) ListPlugins() []Plugin {
+	return append(r.internals.List(), r.plugins.List()...)
+}
+
 // Run is responsible for:
 // 1. Loading internals (chat, http)
 // 2. Loading all plugins


### PR DESCRIPTION
This PR implements the ability to figure out what commands exist by using

```
@<bot name> help <query>
```

Plugins can add their support for the `help.Provider` interface to make commands more discoverable. See [example](https://github.com/botopolis/bot/pull/22/files#diff-261ee5107b1f465d90099358da7b87d5) to see it in action.