### PR TITLE
Support matching bot name when there is a unicode space separator.

### DIFF
--- a/responder_queue.go
+++ b/responder_queue.go
@@ -59,7 +59,7 @@ func newResponderQueue(capacity int) *responderQueue {
 func (e *responderQueue) Forward(r *Robot, ch <-chan Message) {
 	for msg := range ch {
 		rs := newResponder(r, msg)
-		exp := regexp.MustCompile("^@?" + r.Username() + "\\s")
+		exp := regexp.MustCompile("^@?" + r.Username() + "\\p{Zs}")
 		if msg.Type == DefaultMessage && exp.MatchString(msg.Text) {
 			e.Emit(Response, rs)
 		}


### PR DESCRIPTION
Sometimes when copy and pasting messages in slack, the space character
gets pasted as \00a0, a no-break space character. The existing regex
does not recognise this as a space character and does not emit the
Response event.

This is unexpected because on slack it is indistinguishable from a
normal space character.

This commit expands the regex from \s to \p{Zs} which is the unicode
class for space characters. This is a strict superset of \s and will
catch the case where the sent message has unicode space.

Reference:
http://www.unicode.org/Public/UNIDATA/UnicodeData.txt. Search for `Zc`.

To repro:
* Copy a message that looks like `@someone msg`. 
* Paste it in the chat box
* Press esc (to cancel the auto complete) <-- this step is important because pressing enter will trigger an insertion of a space character
* Copy the message in that chat box
* Paste it in a viewer like https://www.soscisurvey.de/tools/view-chars.php
* Observe that U+A0 appears.